### PR TITLE
Check UnderReplicatedPartitions as a string

### DIFF
--- a/src/main/resources/plugins/kafka/TestbotPlugin.py
+++ b/src/main/resources/plugins/kafka/TestbotPlugin.py
@@ -188,7 +188,7 @@ class KafkaWhitebox(PndaPlugin):
                                       'kafka',
                                       'kafka.brokers.%d.UnderReplicatedPartitions' %
                                       broker_id, [], response.text))
-            if response.text != 0:
+            if response.text != "0":
                 self.whitebox_error_code = 101
 
         else:


### PR DESCRIPTION
Currently always fails as we check if it's an integer

PNDA-2483