### PR TITLE
Extra cleanup when hbase test fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## Changed
 - PNDA-2672: Explicitly specify usage of CM API version 11
 
+## Fixed
+- PNDA-2597: Delete HBase folder from HDFS when blackbox test fails as part of cleanup to cope with HBase errors.
+
 ## [0.3.0] 2017-01-20
 ### Changed
 - PNDA-2485: Pinned all python libraries to strict version numbers

--- a/src/main/resources/plugins/cdh_blackbox/TestbotPlugin.py
+++ b/src/main/resources/plugins/cdh_blackbox/TestbotPlugin.py
@@ -160,7 +160,8 @@ class CDHBlackboxPlugin(PndaPlugin):
                 for line in hbase_fix_output.splitlines():
                     if 'Status:' in line or 'inconsistencies detected' in line:
                         LOGGER.debug(line)
-                hbase_fix_output = subprocess.check_output(['sudo', '-u', 'hbase', 'hbase', 'zkcli', 'rmr', '/hbase/table/blackbox_test_table'])
+                subprocess.check_output(['sudo', '-u', 'hbase', 'hbase', 'zkcli', 'rmr', '/hbase/table/blackbox_test_table'])
+                subprocess.check_output(['sudo', '-u', 'hdfs', 'hadoop', 'fs', '-rm', '-r', '-f', '-skipTrash', '/hbase/data/default/blackbox_test_table'])
                 read_hbase_ok = False
                 reason = ['Failed to fetch row by row key from HBase']
             health_values.append(Event(TIMESTAMP_MILLIS(),


### PR DESCRIPTION
When hbase CDH blackbox test fails also delete the folder from HDFS.

PNDA-2597