### PR TITLE
Disable hbase table delete in cdh_blackbox test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+### Changed
+- VPP-17: Change platform-tests from starbase to happybase which is more performant. Also don't create and delete a table as part of the hbase test as this causes the regionserver to leak java heap space.
+
 ## [0.3.1] 2017-06-28
 ### Changed
 - PNDA-2672: Explicitly specify usage of CM API version 11

--- a/src/main/resources/plugins/cdh_blackbox/cm_health.py
+++ b/src/main/resources/plugins/cdh_blackbox/cm_health.py
@@ -119,7 +119,7 @@ class CDHData(object):
 
             for role in service.get_all_roles():
 
-                if role.type == "HBASERESTSERVER":
+                if role.type == "HBASETHRIFTSERVER":
                     self._metadata['hbase_endpoint'] = \
                         self._api.get_host(role.hostRef.hostId).hostname
                 if role.type == "HIVESERVER2":

--- a/src/main/resources/plugins/cdh_blackbox/requirements.txt
+++ b/src/main/resources/plugins/cdh_blackbox/requirements.txt
@@ -5,5 +5,5 @@ ordereddict==1.1
 pyhs2==0.6.0
 sasl==0.2.1
 six==1.10.0
-starbase==0.3.3
+happybase==1.0.0
 thrift==0.9.3

--- a/src/main/resources/plugins/cdh_blackbox/tests/unittests.py
+++ b/src/main/resources/plugins/cdh_blackbox/tests/unittests.py
@@ -32,7 +32,7 @@ class TestCDHBlackboxPlugin(unittest.TestCase):
     Set of unit tests designed to validate cdh-blackbox Plugin
     '''
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.ApiResource')
-    @mock.patch('plugins.cdh_blackbox.TestbotPlugin.starbase.Connection')
+    @mock.patch('plugins.cdh_blackbox.TestbotPlugin.happybase.Connection')
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.pyhs2')
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.connect')
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.CDHData.get_name',
@@ -47,18 +47,18 @@ class TestCDHBlackboxPlugin(unittest.TestCase):
                 lambda s: '0.0.0.0')
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.CDHData.get_status_indicators',
                 lambda s: [])
-    def test_pass_simple(self, impala_connect_mock, p2_mock, starbase_connection_mock, api_mock):
+    def test_pass_simple(self, impala_connect_mock, p2_mock, happybase_connection_mock, api_mock):
         '''
         Test that if all tests pass we get the expected output - no merging of indicators
         '''
         self.assertTrue(p2_mock is not None)
 
-        # mock HBase connection.table.fetch
+        # mock HBase connection.table.row
         _table = mock.MagicMock()
-        _table.fetch.return_value = {'cf': {'column': 'value'}}
+        _table.row.return_value = {'cf:column': 'value'}
         _hbase_conn = mock.MagicMock()
         _hbase_conn.table.return_value = _table
-        starbase_connection_mock.return_value = _hbase_conn
+        happybase_connection_mock.return_value = _hbase_conn
 
         # mock Impala connection.cursor.fetchall
         _cursor = mock.MagicMock()
@@ -116,7 +116,7 @@ class TestCDHBlackboxPlugin(unittest.TestCase):
             index += 1
 
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.ApiResource')
-    @mock.patch('plugins.cdh_blackbox.TestbotPlugin.starbase.Connection')
+    @mock.patch('plugins.cdh_blackbox.TestbotPlugin.happybase.Connection')
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.pyhs2')
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.connect')
     @mock.patch('plugins.cdh_blackbox.TestbotPlugin.CDHData.get_name',
@@ -138,19 +138,19 @@ class TestCDHBlackboxPlugin(unittest.TestCase):
                            Event(0, 'impala01', 'hadoop.IMPALA.cm_indicator',
                                  ['Cause C', 'Cause D'], 'WARN'),
                           ])
-    def test_merge_simple(self, impala_connect_mock, p2_mock, starbase_connection_mock, api_mock):
+    def test_merge_simple(self, impala_connect_mock, p2_mock, happybase_connection_mock, api_mock):
         '''
         Test that merging of indicators with CM is working as expected, with simulated failures
         in both PNDA tests and CM indicators
         '''
         self.assertTrue(p2_mock is not None)
 
-        # mock HBase connection.table.fetch with success
+        # mock HBase connection.table.row with success
         _table = mock.MagicMock()
-        _table.fetch.return_value = {'cf': {'column': 'value'}}
+        _table.row.return_value = {'cf:column': 'value'}
         _hbase_conn = mock.MagicMock()
         _hbase_conn.table.return_value = _table
-        starbase_connection_mock.return_value = _hbase_conn
+        happybase_connection_mock.return_value = _hbase_conn
 
         # mock Impala connection.cursor.fetchall with failure
         _cursor = mock.MagicMock()
@@ -193,7 +193,7 @@ class TestCDHBlackboxPlugin(unittest.TestCase):
         hcheck = {'name': 'host check',
                   'explanation': 'host broken', 'summary': 'BAD'}
 
-        role1 = mock.MagicMock(type='HBASERESTSERVER', healthChecks=[rcheck],
+        role1 = mock.MagicMock(type='HBASETHRIFTSERVER', healthChecks=[rcheck],
                                hostRef=mock.MagicMock(hostId=42))
         role2 = mock.MagicMock(type='HIVESERVER2', healthChecks=[rcheck],
                                hostRef=mock.MagicMock(hostId=42))


### PR DESCRIPTION
Change platform-tests from starbase to happybase which is more
performant. Also don't create and delete a table as part of the hbase
test as this causes the regionserver to leak java heap space.

VPP-17