### PR TITLE
PNDA-4223: End timestamp added for read operation in OpenTSDB plugin

### DIFF
--- a/src/main/resources/plugins/opentsdb/TestbotPlugin.py
+++ b/src/main/resources/plugins/opentsdb/TestbotPlugin.py
@@ -165,7 +165,7 @@ class OpenTSDBWhiteBox(PndaPlugin):
         if not self.create_uid(host, index):
             return False
         url = "%s%s%s" % ("http://", host, "/api/put")
-        payload = {"metric": METRIC_NAME, "timestamp":int(time.time()), \
+        payload = {"metric": METRIC_NAME, "timestamp": TIMESTAMP_MILLIS(), \
         "value": METRIC_VAL, "tags":{TAGK: "%s.%d" % (TAGV, index)}}
         headers = {"content-type": "application/json"}
         try:
@@ -192,7 +192,7 @@ class OpenTSDBWhiteBox(PndaPlugin):
         msg = []
         operation = "READ"
         url = "%s%s%s" % ("http://", host, "/api/query")
-        payload = {"start": self.test_start_timestamp, "queries": [{"aggregator": "none", \
+        payload = {"start": self.test_start_timestamp, "end": TIMESTAMP_MILLIS(), "queries": [{"aggregator": "none", \
         "metric": METRIC_NAME, "tags": {TAGK: "%s.%d" % (TAGV, index)}}]}
         headers = {"content-type": "application/json"}
         try:


### PR DESCRIPTION
## PNDA-4223: OpenTSDB’s platform testing fails with error message - "End time must be greater than the start time"

## Analysis:
- Currently, Platform testing write API call use system time of platform testing node as timestamp along with datapoint. Platform testing read API uses system time of platform testing node as start timestamp in order to fetch the data but not end timestamp.   
- OpenTSDB automatically takes end timestamp as system time. There are scenarios where OpensTSDB node's time is less than the platform testing say by 5 secs. In this case, user see below error
> End time [1518439016772] must be greater than the start time [1518439021959]

## Change 
-	Use platform testing system time as End timestamp in the read API 
-	Consistently use milliseconds for both read and write 
