### PR TITLE
PNDA-4106 Console not reflecting which zookeeper is lost

### DIFF
--- a/src/main/resources/plugins/zookeeper/TestbotPlugin.py
+++ b/src/main/resources/plugins/zookeeper/TestbotPlugin.py
@@ -234,6 +234,11 @@ class ZookeeperBot(PndaPlugin):
                 except ProcessorError, ex:
                     LOGGER.error('Failed to process: %s', str(ex))
                     break
+            else:
+                self.results.append(Event(TIMESTAMP_MILLIS(),
+                                          'zookeeper',
+                                          'zookeeper.%d.mode' % (zid), [], MonitorStatus["red"])
+                                   )
             zid += 1
         if not zk_data:
             zk_data = ZkMonitorSummary(


### PR DESCRIPTION
**PNDA-4106 : Console not reflecting which zookeeper is lost**

Currently, when a zookeeper node is lost (example zk-2), a new leader is elected, but the zk-2 still appears as a leader instead of actual down status.

Now, if the zookeeper leader node is not alive, the status will be set to "ERROR" instead leader.

Test details:
Verified changes in AWS setups:
UBUNTU - STD-HDP
RHEL   - STD-HDP