### PR TITLE
PNDA-4481: Zookeeper status in PNDA console showing as 'ERROR' when l…

### DIFF
--- a/src/main/resources/plugins/kafka/TestbotPlugin.py
+++ b/src/main/resources/plugins/kafka/TestbotPlugin.py
@@ -26,6 +26,7 @@ import time
 import argparse
 import sys
 import os
+import math
 import logging
 import json
 from decimal import Decimal
@@ -342,13 +343,21 @@ class KafkaWhitebox(PndaPlugin):
         analyse_status = MonitorStatus["green"]
         analyse_causes = []
         analyse_metric = 'kafka.health'
+        zk_majority = int(math.ceil(float(len(zk_data.list_zk.split(",")))/2))
 
         if zk_data and zk_data.list_zk_ko:
-            LOGGER.error(
-                "analyse_results : at least one zookeeper node failed")
-            analyse_status = MonitorStatus["red"]
-            analyse_causes.append(
-                "zookeeper node(s) unreachable (%s)" % zk_data.list_zk_ko)
+            if zk_data.num_zk_ok >= zk_majority:
+	        LOGGER.warn(
+		    "analyse_results : at least one zookeeper node failed")
+	        analyse_status = MonitorStatus["amber"]
+	        analyse_causes.append(
+		    "zookeeper node(s) unreachable (%s)" % zk_data.list_zk_ko)
+            else:
+                LOGGER.error(
+                    "analyse_results : at least one zookeeper node failed")
+                analyse_status = MonitorStatus["red"]
+                analyse_causes.append(
+                    "zookeeper node(s) unreachable (%s)" % zk_data.list_zk_ko)
 
         if zk_data and zk_data.list_brokers_ko:
             LOGGER.error("analyse_results : at least one broker failed")

--- a/src/main/resources/plugins/zookeeper/TestbotPlugin.py
+++ b/src/main/resources/plugins/zookeeper/TestbotPlugin.py
@@ -22,6 +22,7 @@ import sys
 import os
 import logging
 import time
+import math
 from prettytable import PrettyTable
 from pnda_plugin import PndaPlugin
 from pnda_plugin import Event
@@ -81,12 +82,20 @@ def analyse_results(zk_data, zk_election):
     analyse_status = MonitorStatus["green"]
     analyse_causes = []
     analyse_metric = 'zookeeper.health'
+    zk_majority = int(math.ceil(float(len(zk_data.list_zk.split(",")))/2))
 
     if zk_data and zk_data.list_zk_ko:
-        LOGGER.error("analyse_results : at least one zookeeper node failed")
-        analyse_status = MonitorStatus["red"]
-        analyse_causes.append(
-            "zookeeper node(s) unreachable (%s)" % zk_data.list_zk_ko)
+        if zk_data.num_zk_ok >= zk_majority:
+	    LOGGER.warn(
+		"analyse_results : at least one zookeeper node failed")
+	    analyse_status = MonitorStatus["amber"]
+	    analyse_causes.append(
+		"zookeeper node(s) unreachable (%s)" % zk_data.list_zk_ko)
+        else:
+            LOGGER.error("analyse_results : at least one zookeeper node failed")
+            analyse_status = MonitorStatus["red"]
+            analyse_causes.append(
+                "zookeeper node(s) unreachable (%s)" % zk_data.list_zk_ko)
     elif zk_election is False:
         LOGGER.error("analyse_results : zookeeper election not done, check nodes mode")
         analyse_status = MonitorStatus["red"]


### PR DESCRIPTION
…oss of one node in a 3-member zookeeper quorum

Currently, Zookeeper status in PNDA console showing as 'ERROR' when loss of one node in a 3-member zookeeper quorum, actually it should be "WARN".

Test details:
Verified changes in AWS setups:
UBUNTU-STD-HDP
RHEL-STD-HDP