### PR TITLE
PNDA-4702: Zookeeper unittest popen mocked

### DIFF
--- a/src/main/resources/plugins/zookeeper/tests/unittests.py
+++ b/src/main/resources/plugins/zookeeper/tests/unittests.py
@@ -16,18 +16,19 @@ either express or implied.
 Purpose:    Unit testing
 
 """
-
+from cStringIO import StringIO
 import unittest
 
 from mock import patch
 from pnda_plugin import Event
 
 class TestKafkaBlackbox(unittest.TestCase):
-
+    @patch('os.popen')
     @patch('plugins.common.zkclient.ZkClient')
-    def test_normal_use(self, zk_mock):
+    def test_normal_use(self, zk_mock, popen_mock):
         from plugins.zookeeper.TestbotPlugin import ZookeeperBot
         zk_mock.return_value.ping.return_value = True
+        popen_mock.return_value = StringIO("Mode: standalone")
         plugin = ZookeeperBot()
         values = plugin.runner(("--zconnect 127.0.0.1:2181"), True)
         self.assertEqual(5, len(values))


### PR DESCRIPTION
**Problem Statement:**
Zookeeper unit test emits  sh: nc: command not found error message during building platform-testing

**Analysis:**
When os.popen tries to execute nc command, it is throwing the error message

**Changes Done:**
Mocked os.popen method to return a file object containing a string using stringio module

